### PR TITLE
fix(filesNotToBrowserCache): properly handle app-data.json & page-data.json files

### DIFF
--- a/__tests__/s3.test.ts
+++ b/__tests__/s3.test.ts
@@ -11,7 +11,12 @@ const defaultParams = {
   s3Path: '',
   syncDelete: true,
   sizeOnly: false,
-  filesNotToBrowserCache: ['*.html', 'sw.js'],
+  filesNotToBrowserCache: [
+    '*.html',
+    'sw.js',
+    'app-data.json',
+    'page-data/**/*.json'
+  ],
   browserCacheDuration: 456,
   cdnCacheDuration: 123,
   debug: false
@@ -26,7 +31,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -40,7 +47,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -54,7 +63,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -68,7 +79,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -82,7 +95,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --size-only --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -96,7 +111,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --debug --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -27711,7 +27711,12 @@ async function deploy() {
         s3Path: (0, core_1.getInput)('dest-s3-path'),
         syncDelete: (0, input_1.getBooleanInput)('sync-delete'),
         sizeOnly: (0, input_1.getBooleanInput)('only-size-changed'),
-        filesNotToBrowserCache: ['*.html', 'page-data/*.json', 'sw.js'],
+        filesNotToBrowserCache: [
+            '*.html',
+            'sw.js',
+            'app-data.json',
+            'page-data/**/*.json'
+        ],
         browserCacheDuration: (0, input_1.getIntInput)('browser-cache-duration'),
         cdnCacheDuration: (0, input_1.getIntInput)('cdn-cache-duration'),
         debug: (0, input_1.getBooleanInput)('debug')

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,12 @@ async function deploy(): Promise<void> {
     s3Path: getInput('dest-s3-path'),
     syncDelete: getBooleanInput('sync-delete'),
     sizeOnly: getBooleanInput('only-size-changed'),
-    filesNotToBrowserCache: ['*.html', 'page-data/*.json', 'sw.js'],
+    filesNotToBrowserCache: [
+      '*.html',
+      'sw.js',
+      'app-data.json',
+      'page-data/**/*.json'
+    ],
     browserCacheDuration: getIntInput('browser-cache-duration'),
     cdnCacheDuration: getIntInput('cdn-cache-duration'),
     debug: getBooleanInput('debug')


### PR DESCRIPTION
# Fix: Correct caching for Gatsby data files (app-data & nested page-data)

## Description

### The Problem
This action currently applies long-term caching (`max-age=31536000`) to critical Gatsby data files that are supposed to be mutable (`max-age=0`). This causes "stale data" issues where users with cached browsers fail to receive updates after a new deployment.

1.  **Missing `app-data.json`:** Gatsby 3+ uses a root `app-data.json` file as a hash map for the build. This was missing from `filesNotToBrowserCache`, so it was being cached for 1 year.
2.  **Shallow Globbing:** The previous pattern `page-data/*.json` was not recursive. It missed:
    * Nested page data (e.g., `page-data/about/page-data.json`).
    * Static Query results (e.g., `page-data/sq/d/12345.json`).

Because these files were treated as immutable assets, browsers would cache old "maps" pointing to non-existent or outdated JavaScript chunks, causing rendering failures on subsequent visits.

### The Solution
I have updated the `filesNotToBrowserCache` default array to:
1.  Include `app-data.json`.
2.  Use the recursive glob `page-data/**/*.json` to catch all nested JSON data files.

### Verification
- [x] Ran `npm run test` locally and all tests passed.
- [x] Tested via a fork on a production Gatsby site; verified that `page-data.json` files now correctly return `cache-control: public, max-age=0, must-revalidate`.