### PR TITLE
Fix: Correct cache headers for app-data and subfolder deployments

### DIFF
--- a/__tests__/s3.test.ts
+++ b/__tests__/s3.test.ts
@@ -11,7 +11,12 @@ const defaultParams = {
   s3Path: '',
   syncDelete: true,
   sizeOnly: false,
-  filesNotToBrowserCache: ['*.html', 'sw.js'],
+  filesNotToBrowserCache: [
+    '*.html',
+    'sw.js',
+    'app-data.json',
+    'page-data/**/*.json'
+  ],
   browserCacheDuration: 456,
   cdnCacheDuration: 123,
   debug: false
@@ -26,7 +31,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -40,7 +47,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -54,7 +63,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -68,7 +79,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -82,7 +95,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --size-only --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -96,7 +111,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --debug --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"'
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ]

--- a/__tests__/s3.test.ts
+++ b/__tests__/s3.test.ts
@@ -13,9 +13,9 @@ const defaultParams = {
   sizeOnly: false,
   filesNotToBrowserCache: [
     '*.html',
-    'sw.js',
-    'app-data.json',
-    'page-data/**/*.json'
+    '*sw.js',
+    '*app-data.json',
+    '*page-data/*.json'
   ],
   browserCacheDuration: 456,
   cdnCacheDuration: 123,
@@ -31,9 +31,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -47,9 +47,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -63,9 +63,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket/mypath --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket/mypath s3://mybucket/mypath --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -79,9 +79,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -95,9 +95,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --delete --size-only --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ],
@@ -111,9 +111,9 @@ describe('aws commands to exec', () => {
         expectedCommands: [
           'aws s3 sync ./public/ s3://mybucket --debug --delete --cache-control "public, max-age=456, immutable, s-maxage=123"',
           'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*.html" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "text/html"',
-          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
-          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
-          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "page-data/**/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*sw.js" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/javascript"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*app-data.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"',
+          'aws s3 cp s3://mybucket s3://mybucket --debug --exclude "*" --include "*page-data/*.json" --recursive --metadata-directive REPLACE --cache-control "public, max-age=0, must-revalidate, s-maxage=123" --content-type "application/json"'
         ]
       }
     ]

--- a/dist/index.js
+++ b/dist/index.js
@@ -27713,9 +27713,9 @@ async function deploy() {
         sizeOnly: (0, input_1.getBooleanInput)('only-size-changed'),
         filesNotToBrowserCache: [
             '*.html',
-            'sw.js',
-            'app-data.json',
-            'page-data/**/*.json'
+            '*sw.js',
+            '*app-data.json',
+            '*page-data/*.json'
         ],
         browserCacheDuration: (0, input_1.getIntInput)('browser-cache-duration'),
         cdnCacheDuration: (0, input_1.getIntInput)('cdn-cache-duration'),

--- a/dist/index.js
+++ b/dist/index.js
@@ -27711,7 +27711,12 @@ async function deploy() {
         s3Path: (0, core_1.getInput)('dest-s3-path'),
         syncDelete: (0, input_1.getBooleanInput)('sync-delete'),
         sizeOnly: (0, input_1.getBooleanInput)('only-size-changed'),
-        filesNotToBrowserCache: ['*.html', 'page-data/*.json', 'sw.js'],
+        filesNotToBrowserCache: [
+            '*.html',
+            'sw.js',
+            'app-data.json',
+            'page-data/**/*.json'
+        ],
         browserCacheDuration: (0, input_1.getIntInput)('browser-cache-duration'),
         cdnCacheDuration: (0, input_1.getIntInput)('cdn-cache-duration'),
         debug: (0, input_1.getBooleanInput)('debug')

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,9 +12,9 @@ async function deploy(): Promise<void> {
     sizeOnly: getBooleanInput('only-size-changed'),
     filesNotToBrowserCache: [
       '*.html',
-      'sw.js',
-      'app-data.json',
-      'page-data/**/*.json'
+      '*sw.js',
+      '*app-data.json',
+      '*page-data/*.json'
     ],
     browserCacheDuration: getIntInput('browser-cache-duration'),
     cdnCacheDuration: getIntInput('cdn-cache-duration'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,12 @@ async function deploy(): Promise<void> {
     s3Path: getInput('dest-s3-path'),
     syncDelete: getBooleanInput('sync-delete'),
     sizeOnly: getBooleanInput('only-size-changed'),
-    filesNotToBrowserCache: ['*.html', 'page-data/*.json', 'sw.js'],
+    filesNotToBrowserCache: [
+      '*.html',
+      'sw.js',
+      'app-data.json',
+      'page-data/**/*.json'
+    ],
     browserCacheDuration: getIntInput('browser-cache-duration'),
     cdnCacheDuration: getIntInput('cdn-cache-duration'),
     debug: getBooleanInput('debug')


### PR DESCRIPTION
# Fix: Correct cache headers for app-data and subfolder deployments

## Description

### The Problem
This action currently applies long-term caching (`max-age=31536000`) to critical Gatsby data files that should be mutable (`max-age=0`). This results in "stale data" errors for users after deployments.

There are two specific issues with the current implementation:

1.  **Missing `app-data.json`:** Gatsby 3+ relies on a root `app-data.json` file as a hash map for the build. This file is currently missing from the exclusion list, causing it to be cached for 1 year.
2.  **Subfolder Deployment Failure:** When using the `dest-s3-path` input to deploy to a subfolder (e.g., `s3://my-bucket/subfolder/`), the current patterns fail to apply. The action passes patterns to the AWS CLI `--include` flag, which matches against the **full file path string**. A pattern like `page-data/*.json` will fail to match `subfolder/page-data/sq/d/123.json` because the string does not start with `page-data`.

### The Solution
I have updated the `filesNotToBrowserCache` array to use patterns compatible with AWS CLI filters for both root and subfolder deployments:

* **`*app-data.json`**: The leading wildcard ensures this matches `app-data.json` at the root OR inside any subfolder (e.g., `subfolder/app-data.json`).
* **`*page-data/*.json`**: 
    * The first `*` handles any directory prefix (e.g., `subfolder/`).
    * The second `*` handles the recursive file path (AWS CLI treats single asterisks as recursive, matching across slashes).

### Changes
* Updated `src/main.ts` to include `app-data.json` and use leading wildcards for path flexibility.
* Updated `__tests__/main.test.ts` to verify that the correct `max-age=0, must-revalidate` headers and `application/json` content types are applied to these files.

### Verification
- [x] Ran `npm run test` locally and all tests passed.
- [x] Verified that the new patterns correctly target Gatsby data files even when `dest-s3-path` is set.